### PR TITLE
Update src/plone/app/workflowmanager/browser/actions.py to include workflow ID in rule name

### DIFF
--- a/src/plone/app/workflowmanager/browser/actions.py
+++ b/src/plone/app/workflowmanager/browser/actions.py
@@ -37,7 +37,7 @@ class AddActionView(Base):
             am = ActionManager()
             rule = am.get_rule(self.selected_transition)
             if rule is None:
-                id = '--workflowmanager--%s' % self.selected_transition.id
+                id = '--workflowmanager--%s--%s' % (self.selected_workflow.id, self.selected_transition.id)
                 r = Rule()
                 r.title = u"%s transition content rule" % self.selected_transition.id
                 r.description = u"This content rule was automatically created by " + \


### PR DESCRIPTION
this is to include the workflow ID in the rule names... there is another file actionmanager.py I'll edit as well as part of this.

(actually it seemed weird to me that very similar code for adding rules is in two places...)

On some reflection, I think this change will cause existing transition actions not to be seen or recognized by the workflow manager, unless we should include upgrade code that looks for rules with the old format name and resaves them under the new name format... Ugh, sorry.
